### PR TITLE
added Server Side Rendering support

### DIFF
--- a/src/Lory.vue
+++ b/src/Lory.vue
@@ -10,8 +10,6 @@
 </template>
 
 <script>
-import { lory } from 'lory.js'
-
 export default {
 
   props: {
@@ -28,6 +26,7 @@ export default {
   },
 
   mounted () {
+    const lory = require('lory.js').lory
     this.slider = lory(this.$el, this.options)
   },
 


### PR DESCRIPTION
importing lory.js when the component is not mounted yet, throws an error during SSR.
moving the import inside the `computed` hook allows `vue-lory` working even with SSR.