### PR TITLE
Using this gives us warnings in webpack based karma tests, possibly t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "vue": ">=2"
   },
   "dependencies": {
-    "lory.js": "^2.2.1"
+    "lory.js": "git+ssh://git@github.com:sebs/lory-1.git"
   }
 }

--- a/src/Lory.vue
+++ b/src/Lory.vue
@@ -32,7 +32,9 @@ export default {
   },
 
   beforeDestroy () {
-    this.slider.destroy()
+    if (this.slider && this.slider.destroy) {
+      this.slider.destroy()
+    }
   }
 
 }

--- a/src/Lory.vue
+++ b/src/Lory.vue
@@ -17,7 +17,11 @@ export default {
   props: {
     options: {
       type: Object,
-      default: () => ({})
+      default: () => {
+        return {
+          offsetleft: 0
+        }
+      }
     }
   },
 


### PR DESCRIPTION
Using this gives us warnings in webpack based karma tests, possibly to the differently executed lifecycle in the test environment 

* this slider is only created on mounted
* if younted is not created, no slider on this, thus destroy is not defined. 

```
ERROR LOG: '[Vue warn]: Error in beforeDestroy hook: "TypeError: null is not an object (evaluating 'this.slider.destroy')"
```