### PR TITLE
Update index.js to support latest vue-loader (13.x.x) / vue (2.4.x)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-exports.Item = require('./Item')
-exports.Lory = require('./Lory')
-exports.Prev = require('./Prev')
-exports.Next = require('./Next')
+exports.Item = require('./Item').default
+exports.Lory = require('./Lory').default
+exports.Prev = require('./Prev').default
+exports.Next = require('./Next').default


### PR DESCRIPTION
see https://github.com/vuejs/vue-loader/releases/tag/v13.0.0
> Breaking Changes
> The esModule option is now true by default, because this is necessary for ES-module-based scope hoisting to work. This means the export from a *.vue file is now an ES module by default, so async components via dynamic import like this will break
> [...]
> Similarly, old CommonJS-style requires will also need to be updated:
```
// before
const Foo = require('./Foo.vue')

// after
const Foo = require('./Foo.vue').default
```