### PR TITLE
use a default slot to allow overriding prev/next svgs

### DIFF
--- a/src/Next.vue
+++ b/src/Next.vue
@@ -1,6 +1,8 @@
 <template>
   <span class="js_next next">
-    <svg xmlns="http://www.w3.org/2000/svg" :width="size" :height="size" viewBox="0 0 501.5 501.5"><g><path :fill="color" d="M199.33 410.622l-55.77-55.508L247.425 250.75 143.56 146.384l55.77-55.507L358.44 250.75z"></path></g></svg>
+    <slot>
+      <svg xmlns="http://www.w3.org/2000/svg" :width="size" :height="size" viewBox="0 0 501.5 501.5"><g><path :fill="color" d="M199.33 410.622l-55.77-55.508L247.425 250.75 143.56 146.384l55.77-55.507L358.44 250.75z"></path></g></svg>
+    </slot>
   </span>
 </template>
 

--- a/src/Prev.vue
+++ b/src/Prev.vue
@@ -1,6 +1,8 @@
 <template>
   <span class="js_prev prev">
-    <svg xmlns="http://www.w3.org/2000/svg" :width="size" :height="size" viewBox="0 0 501.5 501.5"><g><path :fill="color" d="M302.67 90.877l55.77 55.508L254.575 250.75 358.44 355.116l-55.77 55.506L143.56 250.75z"></path></g></svg>
+    <slot>
+      <svg xmlns="http://www.w3.org/2000/svg" :width="size" :height="size" viewBox="0 0 501.5 501.5"><g><path :fill="color" d="M302.67 90.877l55.77 55.508L254.575 250.75 358.44 355.116l-55.77 55.506L143.56 250.75z"></path></g></svg>
+    </slot>
   </span>
 </template>
 


### PR DESCRIPTION
This allows overriding the default prev/next icons like so:

```
<prev slot="actions">
    <span class="icon" aria-hidden="true">
        <i class="icon-chevron-left"></i>
    </span>
</prev>
```